### PR TITLE
BUG: Orden de ranking incorrecto y typo en getDifferense

### DIFF
--- a/lib/components/tableResults.dart
+++ b/lib/components/tableResults.dart
@@ -13,8 +13,8 @@ class Tableresults extends StatefulWidget {
 
 class _TableresultsState extends State<Tableresults> {
 
-  int getDifferense(int alonsoPosition, int sainzPosition, int alonsopositionBet, int sainzPositionBet) {
-    int differenseAlonso = (alonsopositionBet - alonsoPosition).abs();
+  int getDifferense(int alonsoPosition, int sainzPosition, int alonsoPositionBet, int sainzPositionBet) {
+    int differenseAlonso = (alonsoPositionBet - alonsoPosition).abs();
     int differenseSainz = (sainzPositionBet - sainzPosition).abs();
     return differenseAlonso + differenseSainz;
   }
@@ -32,7 +32,8 @@ class _TableresultsState extends State<Tableresults> {
       ),
     )).toList();
 
-    list.sort((a, b) => b.totalDifferense.compareTo(a.totalDifferense));
+    // El ganador es quien tiene MENOR diferencia con el resultado real
+    list.sort((a, b) => a.totalDifferense.compareTo(b.totalDifferense));
 
     return list;
   }
@@ -71,9 +72,9 @@ class _TableresultsState extends State<Tableresults> {
                 color: WidgetStateProperty.resolveWith<Color?>(
                   (Set<WidgetState> states) {
                     if (index == 0) {
-                      return Colors.red; // Primera fila roja
+                      return Colors.green; // Ganador: menor diferencia
                     }
-                    return Colors.green; // Resto verdes
+                    return null;
                   },
                 ),
                 cells: [


### PR DESCRIPTION
Closes #2

## Cambios
- `list.sort` ahora es **ascendente**: gana la apuesta con **menor** diferencia total respecto al resultado real (antes ordenaba de mayor a menor).
- Typo corregido: `alonsopositionBet` → `alonsoPositionBet`.
- La primera fila ahora se resalta en **verde** (ganador) en lugar de roja; el resto sin color especial.

## Verificación
✅ Verificado con `flutter analyze` (Flutter 3.47.1): **0 errores** y los mismos 52 avisos `info` pre-existentes que en `main` (lints de estilo + warning del asset `.env`). Sin issues nuevos introducidos por este PR.