### PR TITLE
BUG: Tipo incorrecto 'Container' en lugar de 'Widget' en Cardpage

### DIFF
--- a/lib/components/cardPage.dart
+++ b/lib/components/cardPage.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 class Cardpage extends StatelessWidget {
   final Image image;
   final String text;
-  final Container container;
+  final Widget container;
 
   Cardpage({required this.image, required this.text, required this.container});
 


### PR DESCRIPTION
Closes #5

## Cambios en `lib/components/cardPage.dart`
- El parámetro `container` pasa de `Container` a `Widget`: `Cardpage` no debe exigir un tipo concreto para el contenido que recibe (los callers actuales pasan `Container`, así que no hay breaking change).

## Verificación
✅ Verificado con `flutter analyze` (Flutter 3.47.1): **0 errores** y los mismos 52 avisos `info` pre-existentes que en `main` (lints de estilo + warning del asset `.env`). Sin issues nuevos introducidos por este PR.