### PR TITLE
BUG: int.parse sin manejo de errores en resultPage

### DIFF
--- a/lib/resultPage.dart
+++ b/lib/resultPage.dart
@@ -9,12 +9,16 @@ class Resultpage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final int? meetingKey = int.tryParse(meetingId);
+
     return Scaffold(
       appBar: AppBar(
         title: Text("Result Page"),
       ),
       body: Center(
-        child: Listresults(meetingKey: int.parse(meetingId)),
+        child: meetingKey == null
+            ? const Text('ID de carrera inválido')
+            : Listresults(meetingKey: meetingKey),
       ),
     );
   }


### PR DESCRIPTION
Closes #10

## Cambios en `lib/resultPage.dart`
- `int.parse(meetingId)` → `int.tryParse`: si el ID no es numérico se muestra `'ID de carrera inválido'` en lugar de lanzar `FormatException` sin capturar.

## Verificación
✅ Verificado con `flutter analyze` (Flutter 3.47.1): **0 errores** y los mismos 52 avisos `info` pre-existentes que en `main` (lints de estilo + warning del asset `.env`). Sin issues nuevos introducidos por este PR.