### PR TITLE
UX: Sin mensaje de error cuando los campos de login están vacíos

### DIFF
--- a/lib/components/FormLogin.dart
+++ b/lib/components/FormLogin.dart
@@ -54,7 +54,15 @@ class _FormloginState extends State<Formlogin> {
               final usuario = usuarioController.text.trim();
               final password = passwordController.text.trim();
 
-              if (usuario.isEmpty || password.isEmpty) return;
+              if (usuario.isEmpty || password.isEmpty) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Por favor, rellena todos los campos'),
+                    backgroundColor: Colors.orange,
+                  ),
+                );
+                return;
+              }
 
               int userId = await validateLogin(usuario, password);
 


### PR DESCRIPTION
Closes #11

## Cambios en `lib/components/FormLogin.dart`
- Si usuario o contraseña están vacíos se muestra un `SnackBar` naranja con *'Por favor, rellena todos los campos'* en lugar de devolver silenciosamente.

## Verificación
✅ Verificado con `flutter analyze` (Flutter 3.47.1): **0 errores** y los mismos 52 avisos `info` pre-existentes que en `main` (lints de estilo + warning del asset `.env`). Sin issues nuevos introducidos por este PR.