### PR TITLE
DEUDA TÉCNICA: Modelos mutables - deberían ser inmutables con final

### DIFF
--- a/lib/models/cicuits.dart
+++ b/lib/models/cicuits.dart
@@ -1,9 +1,9 @@
 enum CircuitsState { result, bet, future }
 
 class Circuit {
-  String name;
-  String imagen;
-  int meetingId;
-  CircuitsState state;
-  Circuit(this.name, this.imagen, this.meetingId, this.state);
+  final String name;
+  final String imagen;
+  final int meetingId;
+  final CircuitsState state;
+  const Circuit(this.name, this.imagen, this.meetingId, this.state);
 }

--- a/lib/models/resultTable.dart
+++ b/lib/models/resultTable.dart
@@ -4,7 +4,7 @@ class ResultTable {
   final int positionSainz;
   final int totalDifferense;
 
-  ResultTable({
+  const ResultTable({
     required this.name,
     required this.positionAlonso,
     required this.positionSainz,

--- a/lib/models/resultsRaces.dart
+++ b/lib/models/resultsRaces.dart
@@ -1,8 +1,8 @@
 class ResultsRaces {
-  int alonsoPositionBet;
-  int sainzPositionBet;
+  final int alonsoPositionBet;
+  final int sainzPositionBet;
 
-  ResultsRaces({
+  const ResultsRaces({
     required this.alonsoPositionBet,
     required this.sainzPositionBet,
   });

--- a/lib/models/resultsUser.dart
+++ b/lib/models/resultsUser.dart
@@ -3,7 +3,7 @@ class ResultsUser {
   final int alonsoPosition;
   final int sainzPosition;
 
-  ResultsUser({
+  const ResultsUser({
     required this.name,
     required this.alonsoPosition,
     required this.sainzPosition,


### PR DESCRIPTION
Closes #12

## Cambios en `lib/models/`
- `Circuit` y `ResultsRaces`: campos ahora `final` (eran mutables) + constructores `const`.
- `ResultsUser` y `ResultTable`: ya eran `final`, se añade constructor `const`.
- Ningún call site mutaba estos objetos, por lo que no hay cambios adicionales necesarios.

## Verificación
✅ Verificado con `flutter analyze` (Flutter 3.47.1): **0 errores** y los mismos 52 avisos `info` pre-existentes que en `main` (lints de estilo + warning del asset `.env`). Sin issues nuevos introducidos por este PR.