### PR TITLE
UX: Campo numérico permite entrada de texto en algunos dispositivos

### DIFF
--- a/lib/components/FromBet.dart
+++ b/lib/components/FromBet.dart
@@ -1,5 +1,6 @@
 import 'package:f1/components/cardPage.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:f1/utils/connectionDataBase.dart';
 
 class FromBet extends StatefulWidget {
@@ -120,6 +121,7 @@ class _FromBetState extends State<FromBet> {
               container: Container(child: TextField(
                   controller: betAlonso,
                   keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                   decoration: InputDecoration(
                     filled: true,
                     fillColor: Colors.white,
@@ -137,6 +139,7 @@ class _FromBetState extends State<FromBet> {
               container: Container(child: TextField(
                   controller: betSainz,
                   keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                   decoration: InputDecoration(
                     filled: true,
                     fillColor: Colors.white,


### PR DESCRIPTION
Closes #14

## Cambios en `lib/components/FromBet.dart`
- `inputFormatters: [FilteringTextInputFormatter.digitsOnly]` en ambos campos de posición: bloquea pegar texto o teclear letras aunque el teclado sea físico.
- `keyboardType: number` se mantiene para seguir mostrando teclado numérico en móvil.

## Verificación
✅ Verificado con `flutter analyze` (Flutter 3.47.1): **0 errores** y los mismos 52 avisos `info` pre-existentes que en `main` (lints de estilo + warning del asset `.env`). Sin issues nuevos introducidos por este PR.