### PR TITLE
BUG: Sin validación de rango en posiciones de apuesta (1-20)

### DIFF
--- a/lib/components/FromBet.dart
+++ b/lib/components/FromBet.dart
@@ -64,6 +64,20 @@ class _FromBetState extends State<FromBet> {
     int alonsoPosition = int.tryParse(betAlonso.text) ?? 0;
     int sainzPosition = int.tryParse(betSainz.text) ?? 0;
 
+    // En F1 solo hay 20 pilotos: la posición válida es 1-20
+    if (alonsoPosition < 1 ||
+        alonsoPosition > 20 ||
+        sainzPosition < 1 ||
+        sainzPosition > 20) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Las posiciones deben estar entre 1 y 20'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      return;
+    }
+
     bool success = await sendBet(
       widget.userId,
       widget.meetingId,


### PR DESCRIPTION
Closes #7

## Cambios en `lib/components/FromBet.dart`
- `_submitBet` rechaza posiciones fuera del rango **1–20** (negativos, 0, >20) con un `SnackBar` naranja: *'Las posiciones deben estar entre 1 y 20'*.
- Complementa la validación existente de campos vacíos.

## Verificación
✅ Verificado con `flutter analyze` (Flutter 3.47.1): **0 errores** y los mismos 52 avisos `info` pre-existentes que en `main` (lints de estilo + warning del asset `.env`). Sin issues nuevos introducidos por este PR.