### PR TITLE
BUG: Imágenes sin manejo de carga ni error

### DIFF
--- a/lib/components/FromBet.dart
+++ b/lib/components/FromBet.dart
@@ -115,7 +115,12 @@ class _FromBetState extends State<FromBet> {
         children: [
         
           Cardpage(
-              image: Image.asset('assets/images/alonso.jpg'),
+              image: Image.asset(
+                'assets/images/alonso.jpg',
+                errorBuilder: (context, error, stackTrace) {
+                  return const Icon(Icons.person, size: 64);
+                },
+              ),
               text: "apuesta a alonso",
               container: Container(child: TextField(
                   controller: betAlonso,
@@ -132,7 +137,12 @@ class _FromBetState extends State<FromBet> {
             ),
 
             Cardpage(
-              image: Image.asset('assets/images/sainz.jpg'),
+              image: Image.asset(
+                'assets/images/sainz.jpg',
+                errorBuilder: (context, error, stackTrace) {
+                  return const Icon(Icons.person, size: 64);
+                },
+              ),
               text: "apuesta a sainz",
               container: Container(child: TextField(
                   controller: betSainz,

--- a/lib/components/listRaces.dart
+++ b/lib/components/listRaces.dart
@@ -78,6 +78,19 @@ class _ListRacesState extends State<ListRaces> {
                     circuit.imagen,
                     height: double.infinity,
                     fit: BoxFit.cover,
+                    loadingBuilder: (context, child, loadingProgress) {
+                      if (loadingProgress == null) return child;
+                      return const Center(
+                        child: CircularProgressIndicator(),
+                      );
+                    },
+                    errorBuilder: (context, error, stackTrace) {
+                      return const Icon(
+                        Icons.error_outline,
+                        size: 48,
+                        color: Colors.grey,
+                      );
+                    },
                   ),
                   text: circuit.name,
                   container: Container(


### PR DESCRIPTION
Closes #6

## Cambios
- `lib/components/listRaces.dart` (`Image.network` de banderas): `loadingBuilder` con `CircularProgressIndicator` y `errorBuilder` con icono de error.
- `lib/components/FromBet.dart`: `errorBuilder` en las imágenes de asset de Alonso y Sainz por si el asset no existe (muestra icono de persona).

## Verificación
✅ Verificado con `flutter analyze` (Flutter 3.47.1): **0 errores** y los mismos 52 avisos `info` pre-existentes que en `main` (lints de estilo + warning del asset `.env`). Sin issues nuevos introducidos por este PR.