### PR TITLE
BUG: Future inicializado en declaración de campo en lugar de initState

### DIFF
--- a/lib/components/listRaces.dart
+++ b/lib/components/listRaces.dart
@@ -14,7 +14,23 @@ class ListRaces extends StatefulWidget {
 }
 
 class _ListRacesState extends State<ListRaces> {
-  Future<List<Circuit>> circuits = getCircuits();
+  late Future<List<Circuit>> circuits;
+
+  @override
+  void initState() {
+    super.initState();
+    circuits = getCircuits();
+  }
+
+  // Recarga la lista de circuitos; el FutureBuilder muestra el spinner
+  // hasta que el nuevo Future termina.
+  Future<void> _reloadCircuits() {
+    final future = getCircuits();
+    setState(() {
+      circuits = future;
+    });
+    return future;
+  }
 
 // Depending on the race status, a button will be created for the following two actions: betting or viewing results.
   ElevatedButton actionCircuit(CircuitsState state, String meetingId) {
@@ -68,7 +84,9 @@ class _ListRacesState extends State<ListRaces> {
                 ],
               ),
             ),
-            child: ListView.builder(
+            child: RefreshIndicator(
+              onRefresh: _reloadCircuits,
+              child: ListView.builder(
               itemCount: data.length,
               itemBuilder: (context, index) {
                 final circuit = data[index];
@@ -88,6 +106,7 @@ class _ListRacesState extends State<ListRaces> {
                   ),
                 );
               },
+              ),
             ),
           );
         } else if (snapshot.hasError) {


### PR DESCRIPTION
Closes #9

## Cambios en `lib/components/listRaces.dart`
- El `Future` de `getCircuits()` se crea ahora en `initState` (`late Future`) en lugar de en la declaración del campo.
- Se añade `RefreshIndicator` con `_reloadCircuits()`: el usuario puede refrescar la lista deslizando, y el indicador espera a que termine el nuevo Future.

## Verificación
✅ Verificado con `flutter analyze` (Flutter 3.47.1): **0 errores** y los mismos 52 avisos `info` pre-existentes que en `main` (lints de estilo + warning del asset `.env`). Sin issues nuevos introducidos por este PR.