### PR TITLE
BUG: Posible incompatibilidad de tipos en meeting_bet (String vs int)

### DIFF
--- a/lib/utils/connectionDataBase.dart
+++ b/lib/utils/connectionDataBase.dart
@@ -31,6 +31,9 @@ Future<void> connectiondatabase() async {
 }
 
 // get all the bets on a race
+// NOTE: meetingBet is a String (OpenF1 meeting_key as text). If the
+// meeting_bet column in Supabase is numeric, these queries will fail
+// silently - see supabase/verify_meeting_bet_type.sql to check it.
 Future<List<ResultsUser>> getBetsForMeeting(String meetingBet) async {
   try {
 

--- a/supabase/verify_meeting_bet_type.sql
+++ b/supabase/verify_meeting_bet_type.sql
@@ -1,0 +1,20 @@
+-- Issue #13: verificar el tipo real de la columna meeting_bet.
+--
+-- El código Dart trata meeting_bet como String en todas las llamadas
+-- (getBetsForMeeting, getBetForMeetingAndUser, sendBet). Ejecuta esta
+-- consulta en el SQL Editor de Supabase para confirmar que la columna
+-- es de texto; si fuera numérica, habría que alinear el código (o la
+-- columna) para evitar errores silenciosos en las queries.
+
+SELECT column_name, data_type
+FROM information_schema.columns
+WHERE table_name = 'bets'
+  AND column_name IN ('meeting_bet', 'user_id', 'alonso_position', 'sainz_position');
+
+-- Si data_type NO es text/character varying para meeting_bet, dos opciones:
+--
+-- a) Alinear la BD con el código (columna a texto):
+--    ALTER TABLE bets ALTER COLUMN meeting_bet TYPE text;
+--
+-- b) Alinear el código con la BD: cambiar String meetingBet por int en
+--    connectionDataBase.dart, FromBet.dart y listRaces.dart.


### PR DESCRIPTION
Closes #13

## Cambios
- `supabase/verify_meeting_bet_type.sql` (nuevo): consulta para comprobar el tipo real de la columna `meeting_bet` en el SQL Editor de Supabase, con las dos opciones de alineación (ALTER a text, o cambiar el Dart a int).
- `lib/utils/connectionDataBase.dart`: comentario documentando que todo el código asume `meeting_bet` como texto.

## Por qué no se cambia el código a ciegas
El código Dart ya usa `String` de forma consistente en las 3 funciones afectadas. Sin poder verificar la BD desde aquí, cambiar a `int` podría romper las queries si la columna es texto. **Acción requerida**: ejecutar el script y, si es numérico, aplicar la opción b).

## Verificación
✅ Verificado con `flutter analyze` (Flutter 3.47.1): **0 errores** y los mismos 52 avisos `info` pre-existentes que en `main` (lints de estilo + warning del asset `.env`). Sin issues nuevos introducidos por este PR.