### PR TITLE
Fix: error de compilación con font_awesome_flutter y Flutter reciente

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,7 +54,7 @@ class LoginPage extends StatelessWidget {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(FontAwesomeIcons.flagCheckered, size: 50, color: Colors.white),
+                  FaIcon(FontAwesomeIcons.flagCheckered, size: 50, color: Colors.white),
                   const Text(
                     "F1 APUESTA",
                     style: TextStyle(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -236,10 +236,10 @@ packages:
     dependency: "direct main"
     description:
       name: font_awesome_flutter
-      sha256: b9011df3a1fa02993630b8fb83526368cf2206a711259830325bab2f1d2a4eb0
+      sha256: "09dcde8ab90ffae1a7d65ff2ef96fc62a17ad9d0ce7c127b317ded676b0d5935"
       url: "https://pub.dev"
     source: hosted
-    version: "10.12.0"
+    version: "11.0.0"
   functions_client:
     dependency: transitive
     description:
@@ -364,10 +364,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -380,10 +380,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -673,10 +673,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -753,10 +753,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -822,5 +822,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=3.10.8 <4.0.0"
+  dart: ">=3.11.0-0 <4.0.0"
   flutter: ">=3.38.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   supabase_flutter: ^2.12.0
   flutter_dotenv: ^6.0.0
   http: ^1.6.0
-  font_awesome_flutter: ^10.12.0
+  font_awesome_flutter: ^11.0.0
   flutter_launcher_icons: ^0.14.4
 
 dev_dependencies:


### PR DESCRIPTION
## Problema
Con Flutter 3.47+ la app no compila:

```
Error: The class 'IconData' can't be extended outside of its library because it's a final class.
class IconDataBrands extends IconData {
```

Flutter hizo `IconData` `final`, y `font_awesome_flutter 10.12.0` lo extiende.

## Solución
- Actualizado `font_awesome_flutter` de `^10.12.0` a `^11.0.0` (ya no extiende `IconData`).
- Adaptación al breaking change de la v11: `Icon(FontAwesomeIcons...)` → `FaIcon(FontAwesomeIcons...)` en `lib/main.dart:57`.

Verificado compilando para web (`flutter build web`) con Flutter 3.47.1.