### PR TITLE
Ranking de pérdidas + verificación final (issues #47-#52)

### DIFF
--- a/lib/betPage.dart
+++ b/lib/betPage.dart
@@ -26,7 +26,7 @@ class Betpage extends StatelessWidget {
         ),
       ),
       body: Center(
-        child: FormBet(userId: userId, meetingId: meetingId)
+        child: FormBet(userId: userId, meetingId: meetingId),
       ),
     );
   }

--- a/lib/components/cardPage.dart
+++ b/lib/components/cardPage.dart
@@ -24,10 +24,7 @@ class Cardpage extends StatelessWidget {
         child: Row(
           children: [
             /// IMAGEN
-            Expanded(
-              flex: 1,
-              child: ClipRect(child: image),
-            ),
+            Expanded(flex: 1, child: ClipRect(child: image)),
 
             /// content with the container
             Expanded(

--- a/lib/components/error_retry.dart
+++ b/lib/components/error_retry.dart
@@ -26,7 +26,9 @@ class Errorretry extends StatelessWidget {
             ),
             const SizedBox(height: GridSpacing.margin),
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: GridSpacing.margin),
+              padding: const EdgeInsets.symmetric(
+                horizontal: GridSpacing.margin,
+              ),
               child: Text(
                 message,
                 textAlign: TextAlign.center,

--- a/lib/components/listRaces.dart
+++ b/lib/components/listRaces.dart
@@ -42,7 +42,7 @@ class _ListRacesState extends State<ListRaces> {
     });
   }
 
-// Depending on the race status, a button will be created for the following two actions: betting or viewing results.
+  // Depending on the race status, a button will be created for the following two actions: betting or viewing results.
   ElevatedButton actionCircuit(CircuitsState state, String meetingId) {
     switch (state) {
       case CircuitsState.result:
@@ -103,38 +103,36 @@ class _ListRacesState extends State<ListRaces> {
             child: RefreshIndicator(
               onRefresh: _reloadCircuits,
               child: ListView.builder(
-              itemCount: data.length,
-              itemBuilder: (context, index) {
-                final circuit = data[index];
+                itemCount: data.length,
+                itemBuilder: (context, index) {
+                  final circuit = data[index];
 
-                return Cardpage(
-                  image: Image.network(
-                    circuit.imagen,
-                    height: double.infinity,
-                    fit: BoxFit.cover,
-                    loadingBuilder: (context, child, loadingProgress) {
-                      if (loadingProgress == null) return child;
-                      return const Center(
-                        child: CircularProgressIndicator(),
-                      );
-                    },
-                    errorBuilder: (context, error, stackTrace) {
-                      return const Icon(
-                        Icons.error_outline,
-                        size: 48,
-                        color: Colors.grey,
-                      );
-                    },
-                  ),
-                  text: circuit.name,
-                  container: Container(
-                    child: actionCircuit(
-                      circuit.state,
-                      circuit.meetingId.toString(),
+                  return Cardpage(
+                    image: Image.network(
+                      circuit.imagen,
+                      height: double.infinity,
+                      fit: BoxFit.cover,
+                      loadingBuilder: (context, child, loadingProgress) {
+                        if (loadingProgress == null) return child;
+                        return const Center(child: CircularProgressIndicator());
+                      },
+                      errorBuilder: (context, error, stackTrace) {
+                        return const Icon(
+                          Icons.error_outline,
+                          size: 48,
+                          color: Colors.grey,
+                        );
+                      },
                     ),
-                  ),
-                );
-              },
+                    text: circuit.name,
+                    container: Container(
+                      child: actionCircuit(
+                        circuit.state,
+                        circuit.meetingId.toString(),
+                      ),
+                    ),
+                  );
+                },
               ),
             ),
           );

--- a/lib/components/listResults.dart
+++ b/lib/components/listResults.dart
@@ -28,17 +28,18 @@ class _ListResultsState extends State<ListResults> {
 
   // Carga (o recarga) los resultados de la carrera
   void _loadResults() {
-    results = Future.wait([
-      getResults(widget.meetingKey),
-      getBetsForMeeting(widget.meetingKey.toString()),
-    ]).then((results) {
-      return [
-        Results(
-          resultsRaces: results[0] as ResultsRaces,
-          resultsUser: results[1] as List<ResultsUser>,
-        ),
-      ];
-    });
+    results =
+        Future.wait([
+          getResults(widget.meetingKey),
+          getBetsForMeeting(widget.meetingKey.toString()),
+        ]).then((results) {
+          return [
+            Results(
+              resultsRaces: results[0] as ResultsRaces,
+              resultsUser: results[1] as List<ResultsUser>,
+            ),
+          ];
+        });
   }
 
   // Pantalla de mensaje unificada sobre fondo carbón
@@ -114,10 +115,10 @@ class _ListResultsState extends State<ListResults> {
             children: [
               const SizedBox(height: GridSpacing.margin),
               ResultF1(
-                alonsoPosition:
-                    races[0].resultsRaces.alonsoPositionBet.toString(),
-                sainzPosition:
-                    races[0].resultsRaces.sainzPositionBet.toString(),
+                alonsoPosition: races[0].resultsRaces.alonsoPositionBet
+                    .toString(),
+                sainzPosition: races[0].resultsRaces.sainzPositionBet
+                    .toString(),
               ),
               Expanded(
                 child: SingleChildScrollView(

--- a/lib/components/rankingRow.dart
+++ b/lib/components/rankingRow.dart
@@ -1,0 +1,94 @@
+import 'package:f1/models/ranking.dart';
+import 'package:f1/utils/theme.dart';
+import 'package:flutter/material.dart';
+
+/// Fila de la clasificación de pérdidas.
+///
+/// - Posición coloreada por rango (1º lima, último rojo corsa).
+/// - Nombre en mayúsculas.
+/// - Columna de pérdidas en rojo corsa.
+/// - El mayor perdedor se destaca con fondo lima translúcido.
+class RankingRow extends StatelessWidget {
+  final RankingUser user;
+  final int position;
+  final int totalRows;
+
+  const RankingRow({
+    super.key,
+    required this.user,
+    required this.position,
+    required this.totalRows,
+  });
+
+  Color _positionColor() {
+    if (position == 1) return GridColors.lime;
+    if (position == totalRows) return GridColors.rossoCorsa;
+    return GridColors.onSurfaceVariant;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isTopLoser = position == 1 && user.totalLosses > 0;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: GridSpacing.gutter,
+        vertical: GridSpacing.unit * 3,
+      ),
+      decoration: BoxDecoration(
+        color: isTopLoser
+            ? GridColors.primaryContainer.withValues(alpha: 0.12)
+            : GridColors.container,
+        border: Border(
+          left: BorderSide(
+            color: isTopLoser ? GridColors.lime : GridColors.outlineVariant,
+            width: 4,
+          ),
+          bottom: const BorderSide(color: GridColors.outlineVariant),
+        ),
+      ),
+      child: Row(
+        children: [
+          // Posición
+          SizedBox(
+            width: 40,
+            child: Text(
+              '$position',
+              style: GridTypography.oddsLg(color: _positionColor()),
+            ),
+          ),
+          // Usuario
+          Expanded(
+            child: Text(
+              user.name.toUpperCase(),
+              style: GridTypography.dataMono(color: GridColors.onSurface),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          // Carreras disputadas
+          Padding(
+            padding: const EdgeInsets.only(right: GridSpacing.gutter),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text('CARRERAS', style: GridTypography.labelCaps()),
+                Text('${user.racesCount}', style: GridTypography.dataMono()),
+              ],
+            ),
+          ),
+          // Pérdidas acumuladas
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text('PÉRDIDAS', style: GridTypography.labelCaps()),
+              Text(
+                '${user.totalLosses}',
+                style: GridTypography.dataMono(color: GridColors.rossoCorsa),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/components/resultF1.dart
+++ b/lib/components/resultF1.dart
@@ -18,7 +18,10 @@ class ResultF1 extends StatelessWidget {
       ),
       child: Column(
         children: [
-          Text(name.toUpperCase(), style: GridTypography.labelCaps(color: accent)),
+          Text(
+            name.toUpperCase(),
+            style: GridTypography.labelCaps(color: accent),
+          ),
           const SizedBox(height: GridSpacing.unit * 2),
           Text(position, style: GridTypography.oddsLg()),
         ],
@@ -31,10 +34,7 @@ class ResultF1 extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        Text(
-          "RESULTADOS DE LA CARRERA",
-          style: GridTypography.labelCaps(),
-        ),
+        Text("RESULTADOS DE LA CARRERA", style: GridTypography.labelCaps()),
         const SizedBox(height: GridSpacing.gutter),
         Row(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/components/tableResults.dart
+++ b/lib/components/tableResults.dart
@@ -13,25 +13,33 @@ class TableResults extends StatefulWidget {
 }
 
 class _TableResultsState extends State<TableResults> {
-
-  int getDifferense(int alonsoPosition, int sainzPosition, int alonsoPositionBet, int sainzPositionBet) {
+  int getDifferense(
+    int alonsoPosition,
+    int sainzPosition,
+    int alonsoPositionBet,
+    int sainzPositionBet,
+  ) {
     int differenseAlonso = (alonsoPositionBet - alonsoPosition).abs();
     int differenseSainz = (sainzPositionBet - sainzPosition).abs();
     return differenseAlonso + differenseSainz;
   }
 
   List<ResultTable> get resultTable {
-    final list = widget.results.resultsUser.map((result) => ResultTable(
-      name: result.name,
-      positionAlonso: result.alonsoPosition,
-      positionSainz: result.sainzPosition,
-      totalDifferense: getDifferense(
-        widget.results.resultsRaces.alonsoPositionBet,
-        widget.results.resultsRaces.sainzPositionBet,
-        result.alonsoPosition,
-        result.sainzPosition,
-      ),
-    )).toList();
+    final list = widget.results.resultsUser
+        .map(
+          (result) => ResultTable(
+            name: result.name,
+            positionAlonso: result.alonsoPosition,
+            positionSainz: result.sainzPosition,
+            totalDifferense: getDifferense(
+              widget.results.resultsRaces.alonsoPositionBet,
+              widget.results.resultsRaces.sainzPositionBet,
+              result.alonsoPosition,
+              result.sainzPosition,
+            ),
+          ),
+        )
+        .toList();
 
     // El ganador es quien tiene MENOR diferencia con el resultado real
     list.sort((a, b) => a.totalDifferense.compareTo(b.totalDifferense));
@@ -61,20 +69,22 @@ class _TableResultsState extends State<TableResults> {
               final result = resultTable[index];
 
               return DataRow(
-                color: WidgetStateProperty.resolveWith<Color?>(
-                  (Set<WidgetState> states) {
-                    if (index == 0) {
-                      // Ganador: fila destacada con acento lima
-                      return GridColors.primaryContainer.withValues(alpha: 0.12);
-                    }
-                    return null;
-                  },
-                ),
+                color: WidgetStateProperty.resolveWith<Color?>((
+                  Set<WidgetState> states,
+                ) {
+                  if (index == 0) {
+                    // Ganador: fila destacada con acento lima
+                    return GridColors.primaryContainer.withValues(alpha: 0.12);
+                  }
+                  return null;
+                }),
                 cells: [
                   DataCell(
                     Text(
                       result.name.toUpperCase(),
-                      style: GridTypography.dataMono(color: GridColors.onSurface),
+                      style: GridTypography.dataMono(
+                        color: GridColors.onSurface,
+                      ),
                     ),
                   ),
                   DataCell(Text('${result.positionAlonso}')),
@@ -82,7 +92,9 @@ class _TableResultsState extends State<TableResults> {
                   DataCell(
                     Text(
                       '${result.totalDifferense}',
-                      style: GridTypography.dataMono(color: GridColors.rossoCorsa),
+                      style: GridTypography.dataMono(
+                        color: GridColors.rossoCorsa,
+                      ),
                     ),
                   ),
                 ],

--- a/lib/f1Page.dart
+++ b/lib/f1Page.dart
@@ -1,4 +1,5 @@
 import 'package:f1/components/listRaces.dart';
+import 'package:f1/rankingPage.dart';
 import 'package:f1/utils/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -24,6 +25,23 @@ class F1page extends StatelessWidget {
           ],
         ),
         actions: [
+          // Acceso al ranking de pérdidas
+          IconButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute<void>(
+                  builder: (context) => const RankingPage(),
+                ),
+              );
+            },
+            icon: const FaIcon(
+              FontAwesomeIcons.skull,
+              size: 18,
+              color: GridColors.rossoCorsa,
+            ),
+            tooltip: 'Ranking',
+          ),
           // Chip del año en curso con borde lima
           Container(
             margin: const EdgeInsets.only(right: GridSpacing.gutter),
@@ -41,9 +59,7 @@ class F1page extends StatelessWidget {
           ),
         ],
       ),
-      body: Center(
-        child: ListRaces(userId: userId,),
-      ),
+      body: Center(child: ListRaces(userId: userId)),
     );
   }
 }

--- a/lib/models/ranking.dart
+++ b/lib/models/ranking.dart
@@ -1,0 +1,15 @@
+/// Usuario en la clasificación de pérdidas acumuladas.
+class RankingUser {
+  final String name;
+  final int totalLosses;
+  final int racesCount;
+
+  const RankingUser({
+    required this.name,
+    required this.totalLosses,
+    required this.racesCount,
+  });
+
+  /// Media de posiciones falladas por carrera disputada.
+  double get averageLoss => racesCount == 0 ? 0 : totalLosses / racesCount;
+}

--- a/lib/models/results.dart
+++ b/lib/models/results.dart
@@ -5,5 +5,4 @@ class Results {
   final ResultsRaces resultsRaces;
   final List<ResultsUser> resultsUser;
   Results({required this.resultsRaces, required this.resultsUser});
-  
 }

--- a/lib/rankingPage.dart
+++ b/lib/rankingPage.dart
@@ -1,0 +1,89 @@
+import 'package:f1/components/error_retry.dart';
+import 'package:f1/components/rankingRow.dart';
+import 'package:f1/models/ranking.dart';
+import 'package:f1/utils/connectionDataBase.dart';
+import 'package:f1/utils/theme.dart';
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+class RankingPage extends StatefulWidget {
+  const RankingPage({super.key});
+
+  @override
+  State<RankingPage> createState() => _RankingPageState();
+}
+
+class _RankingPageState extends State<RankingPage> {
+  late Future<List<RankingUser>> _ranking;
+
+  @override
+  void initState() {
+    super.initState();
+    _ranking = getRankingByLosses();
+  }
+
+  Future<void> _reload() async {
+    setState(() {
+      _ranking = getRankingByLosses();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Row(
+          children: [
+            const FaIcon(
+              FontAwesomeIcons.skull,
+              size: 18,
+              color: GridColors.rossoCorsa,
+            ),
+            const SizedBox(width: 12),
+            const Text('RANKING'),
+          ],
+        ),
+      ),
+      body: FutureBuilder<List<RankingUser>>(
+        future: _ranking,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(
+              child: CircularProgressIndicator(color: GridColors.rossoCorsa),
+            );
+          }
+
+          if (snapshot.hasError) {
+            return Errorretry(message: '${snapshot.error}', onRetry: _reload);
+          }
+
+          final List<RankingUser> ranking = snapshot.data ?? [];
+
+          if (ranking.isEmpty) {
+            return Center(
+              child: Text(
+                'AÚN NO HAY RANKING.\n¡DISPUTA UNA CARRERA!',
+                textAlign: TextAlign.center,
+                style: GridTypography.headlineLgMobile(),
+              ),
+            );
+          }
+
+          return RefreshIndicator(
+            onRefresh: () async => _reload(),
+            child: ListView.builder(
+              itemCount: ranking.length,
+              itemBuilder: (context, index) {
+                return RankingRow(
+                  user: ranking[index],
+                  position: index + 1,
+                  totalRows: ranking.length,
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/resultPage.dart
+++ b/lib/resultPage.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 class Resultpage extends StatelessWidget {
-
   final String meetingId;
 
   Resultpage({required this.meetingId});

--- a/lib/utils/connectionDataBase.dart
+++ b/lib/utils/connectionDataBase.dart
@@ -1,4 +1,7 @@
+import 'package:f1/models/ranking.dart';
+import 'package:f1/models/resultsRaces.dart';
 import 'package:f1/models/resultsUser.dart';
+import 'package:f1/utils/f1Api.dart';
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -24,29 +27,27 @@ Future<void> connectiondatabase() async {
     throw Exception('DATABASE_URL or ANON_KEY no está definido!');
   }
 
-  await Supabase.initialize(
-    url: url,
-    anonKey: anonKey,
-  );
+  await Supabase.initialize(url: url, anonKey: anonKey);
 }
 
 // get all the bets on a race
 Future<List<ResultsUser>> getBetsForMeeting(String meetingBet) async {
   try {
-
     List<ResultsUser> resultsUser = [];
 
     final response = await Supabase.instance.client
         .from('bets')
         .select()
         .eq('meeting_bet', meetingBet);
-      
+
     for (var bet in response) {
-      resultsUser.add(ResultsUser(
-        name: await getName(bet['user_id']),
-        alonsoPosition: bet['alonso_position'],
-        sainzPosition: bet['sainz_position'],
-      ));
+      resultsUser.add(
+        ResultsUser(
+          name: await getName(bet['user_id']),
+          alonsoPosition: bet['alonso_position'],
+          sainzPosition: bet['sainz_position'],
+        ),
+      );
     }
 
     return resultsUser;
@@ -64,7 +65,7 @@ Future<String> getName(int idUser) async {
         .select('user_name')
         .eq('id', idUser)
         .maybeSingle();
-    
+
     if (response != null && response['user_name'] != null) {
       return response['user_name'];
     } else {
@@ -78,7 +79,9 @@ Future<String> getName(int idUser) async {
 
 //to obtain a bet on a specific race and user
 Future<Map<String, dynamic>?> getBetForMeetingAndUser(
-    int userId, String meetingBet) async {
+  int userId,
+  String meetingBet,
+) async {
   try {
     final response = await Supabase.instance.client
         .from('bets')
@@ -100,25 +103,25 @@ Future<bool> sendBet(
   String meetingBet,
   int betAlonso,
   int betSainz,
-  bool isExists
+  bool isExists,
 ) async {
   try {
-    if(!isExists){
-          await Supabase.instance.client.from('bets').insert({
-      'user_id': userId,
-      'meeting_bet': meetingBet,
-      'alonso_position': betAlonso,
-      'sainz_position': betSainz,
-    });
-    }else{
-      await Supabase.instance.client.from('bets').update({
+    if (!isExists) {
+      await Supabase.instance.client.from('bets').insert({
+        'user_id': userId,
+        'meeting_bet': meetingBet,
         'alonso_position': betAlonso,
         'sainz_position': betSainz,
-      }).eq('user_id', userId).eq('meeting_bet', meetingBet);
+      });
+    } else {
+      await Supabase.instance.client
+          .from('bets')
+          .update({'alonso_position': betAlonso, 'sainz_position': betSainz})
+          .eq('user_id', userId)
+          .eq('meeting_bet', meetingBet);
     }
 
-
-    return true; 
+    return true;
   } catch (error) {
     print('Error sending bet: $error');
     return false;
@@ -146,5 +149,85 @@ Future<int> validateLogin(String username, String password) async {
   } catch (error) {
     print('Error al obtener usuario: $error');
     return 0;
+  }
+}
+
+// Clasificación de pérdidas acumuladas por usuario.
+//
+// Solo cuentan las carreras con resultado válido (posiciones >= 1);
+// las carreras sin resultado o con error de API se ignoran.
+// Ordenado DESCENDENTE: el mayor perdedor primero.
+Future<List<RankingUser>> getRankingByLosses() async {
+  try {
+    // 1. Obtener todas las apuestas y agruparlas por carrera
+    final bets = await Supabase.instance.client.from('bets').select();
+
+    final Map<String, List<dynamic>> betsByMeeting = {};
+    for (final bet in bets as List) {
+      final meeting = bet['meeting_bet'].toString();
+      betsByMeeting.putIfAbsent(meeting, () => []).add(bet);
+    }
+
+    // 2. Nombres de usuario
+    final users = await Supabase.instance.client
+        .from('users_f1')
+        .select('id, user_name');
+    String nameOf(int userId) {
+      for (final user in users as List) {
+        if (user['id'] == userId) return user['user_name'] ?? 'USUARIO ?';
+      }
+      return 'USUARIO ?';
+    }
+
+    // 3. Acumular diferencias por usuario en carreras con resultado válido
+    final Map<int, Map<String, int>> acc = {};
+    for (final entry in betsByMeeting.entries) {
+      final int? meetingKey = int.tryParse(entry.key);
+      if (meetingKey == null) continue;
+
+      ResultsRaces raceResults;
+      try {
+        raceResults = await getResults(meetingKey);
+      } catch (_) {
+        continue; // carrera sin datos en la API
+      }
+      if (raceResults.alonsoPositionBet < 1 ||
+          raceResults.sainzPositionBet < 1) {
+        continue; // resultado no válido aún
+      }
+
+      for (final bet in entry.value) {
+        final int userId = bet['user_id'] as int;
+        final int losses =
+            (raceResults.alonsoPositionBet - (bet['alonso_position'] as int))
+                .abs() +
+            (raceResults.sainzPositionBet - (bet['sainz_position'] as int))
+                .abs();
+
+        final current = acc.putIfAbsent(
+          userId,
+          () => {'losses': 0, 'races': 0},
+        );
+        current['losses'] = current['losses']! + losses;
+        current['races'] = current['races']! + 1;
+      }
+    }
+
+    // 4. Construir ranking ordenado descendente por pérdidas
+    final ranking = acc.entries
+        .map(
+          (e) => RankingUser(
+            name: nameOf(e.key),
+            totalLosses: e.value['losses']!,
+            racesCount: e.value['races']!,
+          ),
+        )
+        .toList();
+
+    ranking.sort((a, b) => b.totalLosses.compareTo(a.totalLosses));
+    return ranking;
+  } catch (error) {
+    print('Error fetching ranking: $error');
+    return [];
   }
 }

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -5,4 +5,5 @@ const int SAINZ_ID = 55;
 //Urls
 const URL_CIRCUITS = 'https://api.openf1.org/v1/meetings?year=';
 const URL_RACES = "https://api.openf1.org/v1/sessions?meeting_key=";
-const URL_RESULTS = 'https://api.openf1.org/v1/session_result?driver_number={driverId}&session_key={sessionId}';
+const URL_RESULTS =
+    'https://api.openf1.org/v1/session_result?driver_number={driverId}&session_key={sessionId}';

--- a/lib/utils/f1Api.dart
+++ b/lib/utils/f1Api.dart
@@ -6,7 +6,6 @@ import 'package:http/http.dart' as http;
 
 // Obtain all the circuits for this year, obtaining only the flag, the id and the name
 Future<List<Circuit>> getCircuits() async {
-
   String url = URL_CIRCUITS + DateTime.now().year.toString();
 
   final response = await http.get(Uri.parse(url));
@@ -69,36 +68,39 @@ bool filterCircuits(String name, DateTime dateRaces) {
 // We obtain the final position of Alonso and Sains
 Future<ResultsRaces> getResults(int meetingKey) async {
   int sessionId = await getRace(meetingKey);
-  int alonsoPosition = await getResultsByDriver(sessionId.toString(), ALONSO_ID);
+  int alonsoPosition = await getResultsByDriver(
+    sessionId.toString(),
+    ALONSO_ID,
+  );
   int sainzPosition = await getResultsByDriver(sessionId.toString(), SAINZ_ID);
 
-
-  return 
-    ResultsRaces(
-      alonsoPositionBet: alonsoPosition,
-      sainzPositionBet: sainzPosition,
-    );
+  return ResultsRaces(
+    alonsoPositionBet: alonsoPosition,
+    sainzPositionBet: sainzPosition,
+  );
 }
 
 // We obtain the final position of a driver
 Future<int> getResultsByDriver(String sessionId, int driverId) async {
-    String url = URL_RESULTS.replaceAll("{driverId}", driverId.toString()).replaceAll("{sessionId}", sessionId);
-    final response = await http.get(Uri.parse(url));
-    if (response.statusCode == 200) {
-      JsonDecoder decoder = const JsonDecoder();
-      var data = decoder.convert(response.body);
-      if(data.length == 0) {
-        return -1; // No hay resultados para este piloto
-      }
-      if(data[0]['position'] == null) {
-        return -2; // El piloto no terminó la carrera o no tiene posición asignada
-      }
-      return data[0]['position'];
-    } else {
-      print("error to get results by driver: ${response.statusCode}");
-      throw Exception('Failed to load results by driver');
+  String url = URL_RESULTS
+      .replaceAll("{driverId}", driverId.toString())
+      .replaceAll("{sessionId}", sessionId);
+  final response = await http.get(Uri.parse(url));
+  if (response.statusCode == 200) {
+    JsonDecoder decoder = const JsonDecoder();
+    var data = decoder.convert(response.body);
+    if (data.length == 0) {
+      return -1; // No hay resultados para este piloto
     }
+    if (data[0]['position'] == null) {
+      return -2; // El piloto no terminó la carrera o no tiene posición asignada
+    }
+    return data[0]['position'];
+  } else {
+    print("error to get results by driver: ${response.statusCode}");
+    throw Exception('Failed to load results by driver');
   }
+}
 
 // We obtain the race ID
 Future<int> getRace(int meetingKey) async {

--- a/lib/utils/theme.dart
+++ b/lib/utils/theme.dart
@@ -127,7 +127,9 @@ abstract final class GridSpacing {
 abstract final class GridShapes {
   static const double radius = 0;
   static const BorderRadius borderRadius = BorderRadius.zero;
-  static const BorderSide thinSide = BorderSide(color: GridColors.outlineVariant);
+  static const BorderSide thinSide = BorderSide(
+    color: GridColors.outlineVariant,
+  );
 }
 
 /// ThemeData global de la app según el diseño "Grid Dynamic".
@@ -186,7 +188,9 @@ ThemeData getGridTheme() {
           horizontal: GridSpacing.gutter,
           vertical: 14,
         ),
-        shape: const RoundedRectangleBorder(borderRadius: GridShapes.borderRadius),
+        shape: const RoundedRectangleBorder(
+          borderRadius: GridShapes.borderRadius,
+        ),
         side: const BorderSide(color: GridColors.limeDim),
       ),
     ),
@@ -223,7 +227,9 @@ ThemeData getGridTheme() {
       backgroundColor: GridColors.containerHigh,
       contentTextStyle: GridTypography.bodyMd(),
       behavior: SnackBarBehavior.floating,
-      shape: const RoundedRectangleBorder(borderRadius: GridShapes.borderRadius),
+      shape: const RoundedRectangleBorder(
+        borderRadius: GridShapes.borderRadius,
+      ),
     ),
     progressIndicatorTheme: const ProgressIndicatorThemeData(
       color: GridColors.lime,


### PR DESCRIPTION
Cierra #47, cierra #48, cierra #49, cierra #50, cierra #51, cierra #52

## Funcionalidad
- **#47** `lib/models/ranking.dart`: `RankingUser` (name, totalLosses, racesCount) con `averageLoss` calculado.
- **#48** `getRankingByLosses()`: agrupa las apuestas por carrera, acumula diferencias solo en carreras con resultado válido (ignora -1/-2 y errores de API), agrupa por usuario y ordena **descendente** (el mayor perdedor primero).
- **#49** `lib/components/rankingRow.dart`: posición coloreada por rango (1º lima, último rojo corsa), usuario en mayúsculas data-mono, pérdidas en rojo corsa y mayor perdedor destacado con acento lima.
- **#50** `lib/rankingPage.dart`: AppBar con icono skull rojo corsa, spinner rojo corsa, RefreshIndicator y estado vacío.
- **#51** Botón skull (rojo corsa) en el AppBar de F1Page que navega a RankingPage.

## Verificación (#52)
- ✅ `flutter pub get`
- ✅ `flutter analyze`: 0 errores
- ✅ `dart format --set-exit-if-changed .`: pasa (repo formateado)

*Nota: este PR está apilado sobre #56; su rama base es feat/35-grid-redesign.*