### PR TITLE
Marcar todos los empates en tabla de resultados y ranking (issue #58)

### DIFF
--- a/lib/components/rankingRow.dart
+++ b/lib/components/rankingRow.dart
@@ -12,24 +12,24 @@ class RankingRow extends StatelessWidget {
   final RankingUser user;
   final int position;
   final int totalRows;
+  final bool isTopLoser;
 
   const RankingRow({
     super.key,
     required this.user,
     required this.position,
     required this.totalRows,
+    required this.isTopLoser,
   });
 
   Color _positionColor() {
-    if (position == 1) return GridColors.lime;
+    if (isTopLoser) return GridColors.lime;
     if (position == totalRows) return GridColors.rossoCorsa;
     return GridColors.onSurfaceVariant;
   }
 
   @override
   Widget build(BuildContext context) {
-    final bool isTopLoser = position == 1 && user.totalLosses > 0;
-
     return Container(
       padding: const EdgeInsets.symmetric(
         horizontal: GridSpacing.gutter,

--- a/lib/components/tableResults.dart
+++ b/lib/components/tableResults.dart
@@ -68,11 +68,15 @@ class _TableResultsState extends State<TableResults> {
             rows: List.generate(resultTable.length, (index) {
               final result = resultTable[index];
 
+              // Ganador(es): toda fila con la diferencia mínima (incluye empates)
+              final bool isWinner =
+                  result.totalDifferense == resultTable.first.totalDifferense;
+
               return DataRow(
                 color: WidgetStateProperty.resolveWith<Color?>((
                   Set<WidgetState> states,
                 ) {
-                  if (index == 0) {
+                  if (isWinner) {
                     // Ganador: fila destacada con acento lima
                     return GridColors.primaryContainer.withValues(alpha: 0.12);
                   }

--- a/lib/rankingPage.dart
+++ b/lib/rankingPage.dart
@@ -74,10 +74,14 @@ class _RankingPageState extends State<RankingPage> {
             child: ListView.builder(
               itemCount: ranking.length,
               itemBuilder: (context, index) {
+                // Empates: todos los usuarios con las pérdidas máximas
+                final int topLosses = ranking.first.totalLosses;
                 return RankingRow(
                   user: ranking[index],
                   position: index + 1,
                   totalRows: ranking.length,
+                  isTopLoser:
+                      topLosses > 0 && ranking[index].totalLosses == topLosses,
                 );
               },
             ),


### PR DESCRIPTION
Closes #58

## Cambios
- **Tabla de resultados** (`tableResults.dart`): se marca como ganadora toda fila cuya diferencia total sea igual a la mínima, no solo la primera (`index == 0` → comparación con `resultTable.first.totalDifferense`).
- **Ranking** (`rankingRow.dart` + `rankingPage.dart`): el cálculo del mayor perdedor pasa a la página, que marca como empatados todos los usuarios con las pérdidas máximas (> 0). El color lima de la posición depende ahora del flag en lugar de `position == 1`.

Verificado con `flutter analyze`: 0 errores.