### PR TITLE
Ranking: calcular solo con la base de datos, sin API (issue #59)

### DIFF
--- a/lib/components/listResults.dart
+++ b/lib/components/listResults.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:f1/components/error_retry.dart';
 import 'package:f1/components/resultF1.dart';
 import 'package:f1/components/tableResults.dart';
@@ -26,16 +27,21 @@ class _ListResultsState extends State<ListResults> {
     _loadResults();
   }
 
-  // Carga (o recarga) los resultados de la carrera
+  // Carga (o recarga) los resultados de la carrera.
+  // Guarda también el resultado en la tabla `results` de Supabase
+  // para que el ranking pueda calcularse solo con la base de datos.
   void _loadResults() {
     results =
         Future.wait([
           getResults(widget.meetingKey),
           getBetsForMeeting(widget.meetingKey.toString()),
         ]).then((results) {
+          final raceResults = results[0] as ResultsRaces;
+          // Persistir resultado sin bloquear la UI (fire-and-forget)
+          unawaited(saveRaceResults(widget.meetingKey.toString(), raceResults));
           return [
             Results(
-              resultsRaces: results[0] as ResultsRaces,
+              resultsRaces: raceResults,
               resultsUser: results[1] as List<ResultsUser>,
             ),
           ];

--- a/lib/utils/connectionDataBase.dart
+++ b/lib/utils/connectionDataBase.dart
@@ -1,7 +1,6 @@
 import 'package:f1/models/ranking.dart';
 import 'package:f1/models/resultsRaces.dart';
 import 'package:f1/models/resultsUser.dart';
-import 'package:f1/utils/f1Api.dart';
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -152,23 +151,47 @@ Future<int> validateLogin(String username, String password) async {
   }
 }
 
+// Guarda (upsert) el resultado oficial de una carrera en la tabla results,
+// para que el ranking pueda calcularse solo con la base de datos.
+Future<void> saveRaceResults(
+  String meetingBet,
+  ResultsRaces raceResults,
+) async {
+  try {
+    await Supabase.instance.client.from('results').upsert({
+      'meeting_bet': meetingBet,
+      'alonso_position': raceResults.alonsoPositionBet,
+      'sainz_position': raceResults.sainzPositionBet,
+    });
+  } catch (error) {
+    print('Error guardando el resultado de la carrera: $error');
+  }
+}
+
 // Clasificación de pérdidas acumuladas por usuario.
 //
-// Solo cuentan las carreras con resultado válido (posiciones >= 1);
-// las carreras sin resultado o con error de API se ignoran.
+// Se calcula ÚNICAMENTE con datos de la base de datos: cruza las apuestas
+// (bets) con los resultados oficiales almacenados (results). No se consulta
+// la API de OpenF1. Solo cuentan carreras con resultado guardado.
 // Ordenado DESCENDENTE: el mayor perdedor primero.
 Future<List<RankingUser>> getRankingByLosses() async {
   try {
-    // 1. Obtener todas las apuestas y agruparlas por carrera
+    // 1. Resultados oficiales almacenados en BD, indexados por carrera
+    final savedResults = await Supabase.instance.client
+        .from('results')
+        .select();
+    final Map<String, ResultsRaces> resultsByMeeting = {
+      for (final row in savedResults as List)
+        row['meeting_bet'].toString(): ResultsRaces(
+          alonsoPositionBet: row['alonso_position'] as int,
+          sainzPositionBet: row['sainz_position'] as int,
+        ),
+    };
+
+    // 2. Obtener todas las apuestas
     final bets = await Supabase.instance.client.from('bets').select();
 
-    final Map<String, List<dynamic>> betsByMeeting = {};
-    for (final bet in bets as List) {
-      final meeting = bet['meeting_bet'].toString();
-      betsByMeeting.putIfAbsent(meeting, () => []).add(bet);
-    }
-
-    // 2. Nombres de usuario
+    // 3. Nombres de usuario
     final users = await Supabase.instance.client
         .from('users_f1')
         .select('id, user_name');
@@ -179,41 +202,25 @@ Future<List<RankingUser>> getRankingByLosses() async {
       return 'USUARIO ?';
     }
 
-    // 3. Acumular diferencias por usuario en carreras con resultado válido
+    // 4. Acumular diferencias por usuario en carreras con resultado en BD
     final Map<int, Map<String, int>> acc = {};
-    for (final entry in betsByMeeting.entries) {
-      final int? meetingKey = int.tryParse(entry.key);
-      if (meetingKey == null) continue;
+    for (final bet in bets as List) {
+      final meeting = bet['meeting_bet'].toString();
+      final ResultsRaces? raceResults = resultsByMeeting[meeting];
+      if (raceResults == null) continue; // carrera sin resultado guardado
 
-      ResultsRaces raceResults;
-      try {
-        raceResults = await getResults(meetingKey);
-      } catch (_) {
-        continue; // carrera sin datos en la API
-      }
-      if (raceResults.alonsoPositionBet < 1 ||
-          raceResults.sainzPositionBet < 1) {
-        continue; // resultado no válido aún
-      }
+      final int userId = bet['user_id'] as int;
+      final int losses =
+          (raceResults.alonsoPositionBet - (bet['alonso_position'] as int))
+              .abs() +
+          (raceResults.sainzPositionBet - (bet['sainz_position'] as int)).abs();
 
-      for (final bet in entry.value) {
-        final int userId = bet['user_id'] as int;
-        final int losses =
-            (raceResults.alonsoPositionBet - (bet['alonso_position'] as int))
-                .abs() +
-            (raceResults.sainzPositionBet - (bet['sainz_position'] as int))
-                .abs();
-
-        final current = acc.putIfAbsent(
-          userId,
-          () => {'losses': 0, 'races': 0},
-        );
-        current['losses'] = current['losses']! + losses;
-        current['races'] = current['races']! + 1;
-      }
+      final current = acc.putIfAbsent(userId, () => {'losses': 0, 'races': 0});
+      current['losses'] = current['losses']! + losses;
+      current['races'] = current['races']! + 1;
     }
 
-    // 4. Construir ranking ordenado descendente por pérdidas
+    // 5. Construir ranking ordenado descendente por pérdidas
     final ranking = acc.entries
         .map(
           (e) => RankingUser(

--- a/supabase/results_table.sql
+++ b/supabase/results_table.sql
@@ -1,0 +1,39 @@
+-- ============================================================================
+-- Tabla de resultados oficiales (issue #59)
+--
+-- Ejecutar en el SQL Editor de Supabase.
+--
+-- Almacena el resultado oficial de cada carrera para que el ranking pueda
+-- calcularse únicamente con datos de la base de datos, sin consultar la API
+-- de OpenF1 en cada visita. La app guarda aquí el resultado automáticamente
+-- la primera vez que se consultan los resultados de una carrera.
+-- ============================================================================
+
+create table if not exists public.results (
+  meeting_bet text primary key,
+  alonso_position int not null,
+  sainz_position int not null
+);
+
+-- RLS: la app (anon key) necesita leer para el ranking y escribir para
+-- persistir el resultado al consultarlo. Sin política DELETE.
+alter table public.results enable row level security;
+
+create policy "cualquiera puede ver los resultados"
+  on public.results
+  for select
+  to anon
+  using (true);
+
+create policy "la app puede guardar resultados"
+  on public.results
+  for insert
+  to anon
+  with check (true);
+
+create policy "la app puede actualizar resultados"
+  on public.results
+  for update
+  to anon
+  using (true)
+  with check (true);


### PR DESCRIPTION
Closes #59

## Problema
`getRankingByLosses()` hacía una petición HTTP por carrera a la API de OpenF1 en cada visita al ranking.

## Solución

### Nueva tabla `results` (`supabase/results_table.sql`)
Almacena el resultado oficial de cada carrera una vez consultada. La app lo guarda automáticamente (`saveRaceResults()`) cada vez que se abren los resultados de una carrera — no cambia el comportamiento visible.

### Ranking puramente local
`getRankingByLosses()` ahora cruza `bets` con `results` (ambas en Supabase) y acumula diferencias por usuario en una sola pasada, sin llamar a la API de OpenF1.

### `saveRaceResults()` (nueva función en `connectionDataBase.dart`)
Upser into `results` usando la misma llamada que la pantalla de resultados ya realiza. Se ejecuta de forma no bloqueante (`unawaited`).

### Dependencia eliminada
Se elimina la importación de `f1Api.dart` de `connectionDataBase.dart` (ya no la necesita).

## Acción requerida tras mergear
Ejecutar el script `supabase/results_table.sql` en el SQL Editor de Supabase para crear la tabla.

Verificado con `flutter analyze`: 0 errores.