### PR TITLE
FIX: BuildContext tras await en FormLogin causa crash en APK (issue #67)

### DIFF
--- a/lib/components/FormLogin.dart
+++ b/lib/components/FormLogin.dart
@@ -65,6 +65,8 @@ class _FormloginState extends State<Formlogin> {
 
             int userId = await validateLogin(usuario, password);
 
+            if (!mounted) return;
+
             // go to the main page
             if (userId != 0) {
               Navigator.push(


### PR DESCRIPTION
Closes #67

## Problema
 usaba  despues de  sin comprobar . En APK, el widget podia desmontarse durante el , causando crash silencioso.

## Solucion
Anadido  despues del  y antes de usar  para  y .

## Verificacion
- flutter analyze: 0 errores, solo info lints
- flutter build apk --debug: compila correctamente