### PR TITLE
FIX: dotenv fallback sobreescribe valores validos (issue #70)

### DIFF
--- a/lib/utils/connectionDataBase.dart
+++ b/lib/utils/connectionDataBase.dart
@@ -17,9 +17,11 @@ Future<void> connectiondatabase() async {
   String? url = dotenv.env['DATABASE_URL'];
   String? anonKey = dotenv.env['ANON_KEY'];
 
-  // Revisar null o cadena vacía
-  if (url == null || url.isEmpty || anonKey == null || anonKey.isEmpty) {
+  // Fallback individual por si .env no tiene alguna variable
+  if (url == null || url.isEmpty) {
     url = const String.fromEnvironment('DATABASE_URL');
+  }
+  if (anonKey == null || anonKey.isEmpty) {
     anonKey = const String.fromEnvironment('ANON_KEY');
   }
 


### PR DESCRIPTION
Closes #70

## Problema
En connectiondatabase(), si una variable de entorno era valida y la otra era null/empty, AMBAS se reemplazaban con String.fromEnvironment (vacio). Esto sobreescribia un valor valido con cadena vacia.

## Solucion
Anadir fallback individual por cada variable en lugar de reemplazar ambas en bloque.
