### PR TITLE
FIX: FormBet mounted check tras await (issue #71)

### DIFF
--- a/lib/components/FormBet.dart
+++ b/lib/components/FormBet.dart
@@ -34,6 +34,8 @@ class _FormBetState extends State<FormBet> {
       widget.meetingId,
     );
 
+    if (!mounted) return;
+
     if (bet != null) {
       int? positionAlonso = bet['alonso_position'];
       int? positionSainz = bet['sainz_position'];


### PR DESCRIPTION
Closes #71

## Problema
FormBet._checkIfBetExists() ejecutaba await en initState y luego llamaba a setState() sin comprobar mounted. Podia causar error si el usuario navegaba hacia atras durante la consulta.

## Solucion
Anadir `if (!mounted) return;` despues del await y antes de setState.
