### PR TITLE
FIX: validateLogin oculta errores reales detras de 'Credenciales incorrectas' (issue #72)

### DIFF
--- a/lib/components/FormLogin.dart
+++ b/lib/components/FormLogin.dart
@@ -63,24 +63,34 @@ class _FormloginState extends State<Formlogin> {
               return;
             }
 
-            int userId = await validateLogin(usuario, password);
+            final result = await validateLogin(usuario, password);
 
             // go to the main page
-            if (userId != 0) {
+            if (result.userId != 0) {
               Navigator.push(
                 context,
                 MaterialPageRoute<void>(
-                  builder: (context) => F1page(userId: userId),
+                  builder: (context) => F1page(userId: result.userId),
                 ),
               );
 
               //show a error message
             } else {
+              String msg;
+              Color bg;
+              switch (result.error) {
+                case LoginError.networkError:
+                  msg = 'Error de conexion. Intentalo de nuevo.';
+                  bg = Colors.orange;
+                  break;
+                case LoginError.wrongCredentials:
+                default:
+                  msg = 'Credenciales incorrectas';
+                  bg = GridColors.rossoCorsa;
+                  break;
+              }
               ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text('Credenciales incorrectas'),
-                  backgroundColor: GridColors.rossoCorsa,
-                ),
+                SnackBar(content: Text(msg), backgroundColor: bg),
               );
             }
           },

--- a/lib/utils/connectionDataBase.dart
+++ b/lib/utils/connectionDataBase.dart
@@ -129,10 +129,19 @@ Future<bool> sendBet(
   }
 }
 
+enum LoginError { none, wrongCredentials, networkError, unknown }
+
+class LoginResult {
+  final int userId;
+  final LoginError error;
+
+  const LoginResult(this.userId, [this.error = LoginError.none]);
+}
+
 // check if the username and password exist in the database.
 // Las contraseñas se almacenan hasheadas con bcrypt; si se encuentra una
 // contraseña legacy en texto plano, se verifica y se actualiza a hash.
-Future<int> validateLogin(String username, String password) async {
+Future<LoginResult> validateLogin(String username, String password) async {
   try {
     // Filtramos directamente en la consulta
     final response = await Supabase.instance.client
@@ -141,24 +150,26 @@ Future<int> validateLogin(String username, String password) async {
         .eq('user_name', username)
         .maybeSingle(); // devuelve null si no hay coincidencia
 
-    if (response == null) return 0;
+    if (response == null) return const LoginResult(0, LoginError.wrongCredentials);
 
     final String storedPassword = response['password'] ?? '';
 
     if (_isBcryptHash(storedPassword)) {
-      return BCrypt.checkpw(password, storedPassword) ? response['id'] : 0;
+      return BCrypt.checkpw(password, storedPassword)
+          ? LoginResult(response['id'] as int)
+          : const LoginResult(0, LoginError.wrongCredentials);
     }
 
     // Migración transparente: hash de contraseñas legacy en texto plano
     if (storedPassword == password) {
-      await _upgradeStoredPasswordToHash(response['id'], password);
-      return response['id'];
+      await _upgradeStoredPasswordToHash(response['id'] as int, password);
+      return LoginResult(response['id'] as int);
     }
 
-    return 0;
+    return const LoginResult(0, LoginError.wrongCredentials);
   } catch (error) {
     print('Error al obtener usuario: $error');
-    return 0;
+    return const LoginResult(0, LoginError.networkError);
   }
 }
 


### PR DESCRIPTION
Closes #72

## Problema
validateLogin() capturaba todos los errores y devolvia 0 silenciosamente. El usuario solo veia "Credenciales incorrectas" sin importar si era un error de red, de Supabase o de credenciales reales.

## Solucion
- Nuevo tipo `LoginResult` con `userId` y `error` (enum `LoginError`)
- Tipos de error diferenciados: wrongCredentials, networkError, unknown
- FormLogin muestra mensajes diferentes segun el tipo de error
- Casting explicito de `response['id']` a `int` (antes era dynamic implicito)
