### PR TITLE
FIX: limite de apuesta hasta el jueves de la semana de la carrera (issue #81)

### DIFF
--- a/lib/utils/f1Api.dart
+++ b/lib/utils/f1Api.dart
@@ -19,11 +19,14 @@ Future<List<Circuit>> getCircuits() async {
         circuit['meeting_name'],
         DateTime.parse(circuit['date_end']),
       )) {
-        int difference = DateTime.parse(
-          circuit['date_end'],
-        ).difference(DateTime.now()).inDays;
+        // La fecha máxima para apostar es el jueves de la semana de la carrera.
+        // La carrera (date_end) suele ser el domingo, por lo que el jueves
+        // equivale a date_end - 3 días. A partir del viernes pasa a RESULTADOS.
+        final dateEnd = DateTime.parse(circuit['date_end']);
+        final jueves = dateEnd.subtract(const Duration(days: 3));
+        final int difference = _daysFromToday(jueves);
 
-        if (difference <= 0) {
+        if (difference < 0) {
           circuits.add(
             Circuit(
               circuit['meeting_name'],
@@ -58,6 +61,15 @@ Future<List<Circuit>> getCircuits() async {
   }
 
   return circuits;
+}
+
+// Días desde hoy hasta [date], normalizando ambos a medianoche.
+// Devuelve un valor negativo si [date] ya pasó hoy.
+int _daysFromToday(DateTime date) {
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+  final day = DateTime(date.year, date.month, date.day);
+  return day.difference(today).inDays;
 }
 
 // We removed the Preseason races because there are no bets on those types of races.


### PR DESCRIPTION
Closes #81

## Problema
El estado de cada carrera se decide usando `date_end` (domingo) con la regla `difference < 7`, permitiendo apostar hasta el domingo de la carrera.

## Cambio
- La fecha máxima para apostar es ahora el **jueves de la semana de la carrera** (`date_end - 3 días`).
- A partir del **viernes** la carrera muestra RESULTADOS.
- Se añade `_daysFromToday()` que compara ambos días normalizados a medianoche para evitar desfases por la hora.
- Se mantiene el estado FUTURA para carreras lejanas.

## Archivos
- `lib/utils/f1Api.dart`
