### PR TITLE
FEAT: mostrar la fecha de la carrera en la lista (issue #82)

### DIFF
--- a/lib/components/cardPage.dart
+++ b/lib/components/cardPage.dart
@@ -5,8 +5,14 @@ class Cardpage extends StatelessWidget {
   final Image image;
   final String text;
   final Widget container;
+  final String? date;
 
-  Cardpage({required this.image, required this.text, required this.container});
+  Cardpage({
+    required this.image,
+    required this.text,
+    required this.container,
+    this.date,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -44,6 +50,16 @@ class Cardpage extends StatelessWidget {
                       maxLines: 2,
                       overflow: TextOverflow.ellipsis,
                     ),
+
+                    if (date != null) ...[
+                      const SizedBox(height: GridSpacing.unit),
+                      Text(
+                        date!,
+                        style: GridTypography.dataMono(
+                          color: GridColors.outline,
+                        ),
+                      ),
+                    ],
 
                     const SizedBox(height: GridSpacing.unit * 3),
 

--- a/lib/components/listRaces.dart
+++ b/lib/components/listRaces.dart
@@ -18,6 +18,13 @@ class ListRaces extends StatefulWidget {
 class _ListRacesState extends State<ListRaces> {
   late Future<List<Circuit>> circuits;
 
+  // Formatea la fecha de la carrera como dd/MM/yyyy
+  String _formatDate(DateTime date) {
+    final d = date.day.toString().padLeft(2, '0');
+    final m = date.month.toString().padLeft(2, '0');
+    return '$d/$m/${date.year}';
+  }
+
   @override
   void initState() {
     super.initState();
@@ -125,6 +132,7 @@ class _ListRacesState extends State<ListRaces> {
                       },
                     ),
                     text: circuit.name,
+                    date: _formatDate(circuit.dateEnd),
                     container: Container(
                       child: actionCircuit(
                         circuit.state,

--- a/lib/models/circuits.dart
+++ b/lib/models/circuits.dart
@@ -5,5 +5,12 @@ class Circuit {
   final String imagen;
   final int meetingId;
   final CircuitsState state;
-  const Circuit(this.name, this.imagen, this.meetingId, this.state);
+  final DateTime dateEnd;
+  const Circuit(
+    this.name,
+    this.imagen,
+    this.meetingId,
+    this.state, {
+    required this.dateEnd,
+  });
 }

--- a/lib/utils/f1Api.dart
+++ b/lib/utils/f1Api.dart
@@ -23,6 +23,8 @@ Future<List<Circuit>> getCircuits() async {
           circuit['date_end'],
         ).difference(DateTime.now()).inDays;
 
+        final dateEnd = DateTime.parse(circuit['date_end']);
+
         if (difference <= 0) {
           circuits.add(
             Circuit(
@@ -30,6 +32,7 @@ Future<List<Circuit>> getCircuits() async {
               circuit['country_flag'],
               circuit['meeting_key'],
               CircuitsState.result,
+              dateEnd: dateEnd,
             ),
           );
         } else if (difference < 7) {
@@ -39,6 +42,7 @@ Future<List<Circuit>> getCircuits() async {
               circuit['country_flag'],
               circuit['meeting_key'],
               CircuitsState.bet,
+              dateEnd: dateEnd,
             ),
           );
         } else {
@@ -48,6 +52,7 @@ Future<List<Circuit>> getCircuits() async {
               circuit['country_flag'],
               circuit['meeting_key'],
               CircuitsState.future,
+              dateEnd: dateEnd,
             ),
           );
         }


### PR DESCRIPTION
Closes #82

## Descripción
Muestra la fecha de la carrera en la tarjeta de cada circuito de la lista, sin alterar la imagen, el título ni el botón. La fecha se inserta entre el título y el botón con la tipografía mono del sistema Grid Dynamic (`GridTypography.dataMono`) y un tamaño discreto.

## Cambios
- `lib/models/circuits.dart`: campo nuevo `dateEnd` (DateTime) en `Circuit`.
- `lib/utils/f1Api.dart`: se rellena `dateEnd` a partir de `date_end` en los 3 estados.
- `lib/components/cardPage.dart`: prop opcional `date`, mostrada entre el título y el contenedor (solo si no es null).
- `lib/components/listRaces.dart`: formatea `dateEnd` como `dd/MM/yyyy` y lo pasa al `Cardpage`.

## Diseño
- Se mantiene intacta la imagen, el título en mayúsculas y el botón.
- Solo se añade una línea discreta de fecha con tipografía mono y color `outline`.
- El `date` es opcional, así que otras tarjetas que no usen el campo no cambian.
