### PR TITLE
FIX: boton de la tarjeta se sale y no se pulsa en movil (issue #88)

### DIFF
--- a/lib/components/cardPage.dart
+++ b/lib/components/cardPage.dart
@@ -30,11 +30,11 @@ class Cardpage extends StatelessWidget {
         child: Row(
           children: [
             /// IMAGEN
-            Expanded(flex: 1, child: ClipRect(child: image)),
+            Expanded(flex: 3, child: ClipRect(child: image)),
 
             /// content with the container
             Expanded(
-              flex: 1,
+              flex: 5,
               child: Padding(
                 padding: const EdgeInsets.all(GridSpacing.gutter),
                 child: Column(

--- a/lib/components/listRaces.dart
+++ b/lib/components/listRaces.dart
@@ -133,7 +133,8 @@ class _ListRacesState extends State<ListRaces> {
                     ),
                     text: circuit.name,
                     date: _formatDate(circuit.dateEnd),
-                    container: Container(
+                    container: SizedBox(
+                      width: double.infinity,
                       child: actionCircuit(
                         circuit.state,
                         circuit.meetingId.toString(),


### PR DESCRIPTION
Closes #88

## Problema
En móvil (probado en Galaxy A35 5G, 360dp) el botón de la tarjeta de carrera (APOSTAR/RESULTADOS/FUTURA) se desborda fuera de la tarjeta y no se puede pulsar.

## Causa raíz
`lib/components/cardPage.dart` repartía el ancho de la tarjeta al 50/50 (imagen : contenido) con dos `Expanded(flex: 1)`. En 360dp, el contenido quedaba con ~132dp útiles, por lo que el botón desbordaba la columna y quedaba inaccesible.

## Solución
- `cardPage.dart`: reparto asimétrico imagen `flex: 3` / contenido `flex: 5`, dando más ancho al contenido y al botón.
- `listRaces.dart`: el botón ahora se envuelve en un `SizedBox(width: double.infinity)` para que ocupe todo el ancho disponible y sea fácilmente pulsable.

## Verificación
- `flutter analyze`: sin errores ni warnings.
- `dart format`: exit=0.
