### PR TITLE
FIX: reducir el titulo del AppBar para que no se solape con el anho (issue #90)

### DIFF
--- a/lib/f1Page.dart
+++ b/lib/f1Page.dart
@@ -20,7 +20,14 @@ class F1page extends StatelessWidget {
               color: GridColors.lime,
             ),
             const SizedBox(width: 12),
-            const Text('F1 ALL RACES'),
+            const Text(
+              'F1 ALL RACES',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
           ],
         ),
         actions: [


### PR DESCRIPTION
Closes #90

## Problema
En móvil (Galaxy A35 5G, 360dp) el título "F1 ALL RACES" del AppBar se solapa con el chip del año (2026) situado en `actions`.

## Causa raíz
El `AppBar.titleTextStyle` del tema usa `GridTypography.headlineLgMobile()` (fontSize 24, itálica, w700), que es demasiado grande para que quepa en pantallas estrechas junto al chip del año.

## Solución
- `lib/f1Page.dart`: se aplica un `TextStyle` con `fontSize: 16` al título "F1 ALL RACES" (manteniendo `fontWeight: w700` y `fontStyle: italic` de la estética Grid Dynamic), de modo que ya no se solapa con el año.

## Verificación
- `flutter analyze`: sin errores ni warnings.
- `dart format`: exit=0.
