### PR TITLE
FIX: avisar cuando la API de F1 no esta disponible temporalmente (sesion en directo) - issue #92

### DIFF
--- a/lib/components/listRaces.dart
+++ b/lib/components/listRaces.dart
@@ -49,6 +49,13 @@ class _ListRacesState extends State<ListRaces> {
     });
   }
 
+  // Mensaje mostrado ante un error: específico para la API no disponible
+  // temporalmente (sesión en directo), genérico para el resto.
+  String _errorMessage(Object? error) {
+    if (error is ApiUnavailableException) return error.message;
+    return "Error loading circuits, please try again.";
+  }
+
   // Depending on the race status, a button will be created for the following two actions: betting or viewing results.
   ElevatedButton actionCircuit(CircuitsState state, String meetingId) {
     switch (state) {
@@ -147,7 +154,7 @@ class _ListRacesState extends State<ListRaces> {
           );
         } else if (snapshot.hasError) {
           return Errorretry(
-            message: "Error loading circuits, please try again.",
+            message: _errorMessage(snapshot.error),
             onRetry: _retryLoad,
           );
         } else {

--- a/lib/utils/f1Api.dart
+++ b/lib/utils/f1Api.dart
@@ -4,11 +4,37 @@ import 'package:f1/models/resultsRaces.dart';
 import 'package:f1/utils/constants.dart';
 import 'package:http/http.dart' as http;
 
+// Marca que identifica el bloqueo de OpenF1 durante una sesión de F1 en directo.
+const String _liveF1SessionMarker = 'Live F1 session in progress';
+
+// Excepción lanzada cuando la API de OpenF1 está temporalmente no disponible
+// (por ejemplo, bloqueada durante una sesión en directo).
+class ApiUnavailableException implements Exception {
+  final String message;
+  const ApiUnavailableException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+// Si la respuesta HTTP es un 401 por sesión en directo, lanza
+// ApiUnavailableException; en caso contrario devuelve la respuesta sin cambios.
+http.Response _checkLiveSessionBlock(http.Response response) {
+  if (response.statusCode == 401 &&
+      response.body.contains(_liveF1SessionMarker)) {
+    throw const ApiUnavailableException(
+      'La API de F1 no está disponible temporalmente. Espera a que termine la '
+      'sesión de F1 en directo para ingresar.',
+    );
+  }
+  return response;
+}
+
 // Obtain all the circuits for this year, obtaining only the flag, the id and the name
 Future<List<Circuit>> getCircuits() async {
   String url = URL_CIRCUITS + DateTime.now().year.toString();
 
-  final response = await http.get(Uri.parse(url));
+  final response = _checkLiveSessionBlock(await http.get(Uri.parse(url)));
 
   JsonDecoder decoder = const JsonDecoder();
   List<Circuit> circuits = [];
@@ -100,7 +126,7 @@ Future<int> getResultsByDriver(String sessionId, int driverId) async {
   String url = URL_RESULTS
       .replaceAll("{driverId}", driverId.toString())
       .replaceAll("{sessionId}", sessionId);
-  final response = await http.get(Uri.parse(url));
+  final response = _checkLiveSessionBlock(await http.get(Uri.parse(url)));
   if (response.statusCode == 200) {
     JsonDecoder decoder = const JsonDecoder();
     var data = decoder.convert(response.body);
@@ -121,7 +147,7 @@ Future<int> getResultsByDriver(String sessionId, int driverId) async {
 Future<int> getRace(int meetingKey) async {
   String url = URL_RACES + meetingKey.toString();
 
-  final response = await http.get(Uri.parse(url));
+  final response = _checkLiveSessionBlock(await http.get(Uri.parse(url)));
   if (response.statusCode == 200) {
     JsonDecoder decoder = const JsonDecoder();
     var data = decoder.convert(response.body);


### PR DESCRIPTION
Closes #92

## Problema
Al obtener las carreras, si la API de OpenF1 está bloqueada (HTTP 401 por una sesión de F1 en directo), la app mostraba un mensaje genérico: "Error loading circuits, please try again." Sin explicar al usuario que era un bloqueo temporal de la API externa.

## Cambios
### `lib/utils/f1Api.dart`
- Se añade la constante `_liveF1SessionMarker` y la excepción tipada `ApiUnavailableException`.
- Nueva función `_checkLiveSessionBlock()`: si la respuesta HTTP es **401** y el cuerpo contiene `"Live F1 session in progress"`, lanza `ApiUnavailableException` con el mensaje claro.
- Se aplica la comprobación en `getCircuits()`, `getRace()` y `getResultsByDriver()`.

### `lib/components/listRaces.dart`
- El error se muestra mediante `_errorMessage(snapshot.error)`: si es `ApiUnavailableException`, muestra el mensaje específico; en caso contrario, el genérico.

## Mensaje que verá el usuario
> "La API de F1 no está disponible temporalmente. Espera a que termine la sesión de F1 en directo para ingresar."

## Verificación
- `flutter analyze` (f1Api.dart, listRaces.dart): sin errores ni warnings.
- `dart format --set-exit-if-changed`: exit=0.
